### PR TITLE
Adapt to method signature change in JRuby

### DIFF
--- a/src/main/java/org/jruby/mains/JRubyMain.java
+++ b/src/main/java/org/jruby/mains/JRubyMain.java
@@ -54,11 +54,11 @@ public class JRubyMain extends Main {
         catch (Throwable t) {
             // print out as a nice Ruby backtrace
             System.err.println(ThreadContext
-                    .createRawBacktraceStringFromThrowable(t));
+                    .createRawBacktraceStringFromThrowable(t, false));
             while ((t = t.getCause()) != null) {
                 System.err.println("Caused by:");
                 System.err.println(ThreadContext
-                        .createRawBacktraceStringFromThrowable(t));
+                        .createRawBacktraceStringFromThrowable(t, false));
             }
             System.exit(1);
         }


### PR DESCRIPTION
The signature of this method changed in 9.1.2.0, the second arg was added.

Specifically here:

https://github.com/jruby/jruby/commit/ea8a70c315dff11e93832adf4f88d514c81faba1
